### PR TITLE
feat: disable buttons

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ GitHub Merge Guardian is a browser extension that helps to prevent incorrect mer
 - Configure multiple rules based on owner, repository name, base branch, compare branch, and merge strategy.
 - Use * as a wildcard in each item.
 - Change the merge button color to draw attention when the merge strategy doesn't match the configured rules.
-- Merge button color change only indicates the suggestion; you can still perform other merge strategies if needed.
 - To prevent accidental merging, the merge button is disabled when the merge strategy doesn't match the configured rules.
 - Customize the merge button color.
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ GitHub Merge Guardian is a browser extension that helps to prevent incorrect mer
 - Use * as a wildcard in each item.
 - Change the merge button color to draw attention when the merge strategy doesn't match the configured rules.
 - Merge button color change only indicates the suggestion; you can still perform other merge strategies if needed.
+- To prevent accidental merging, the merge button is disabled when the merge strategy doesn't match the configured rules.
 - Customize the merge button color.
 
 ## Install

--- a/src/contents/github.ts
+++ b/src/contents/github.ts
@@ -92,12 +92,14 @@ const applySetting = (settings: Setting[]) => {
       execElement?.classList.remove(styles.execButton)
     } else {
       selectElement?.classList.add(styles.selectButton)
+      if (selectElement !== null) selectElement.disabled = true
       selectElement?.addEventListener(
         "click",
         changeMenuButtonColorWarning,
         abortController ? { signal: abortController.signal } : undefined
       )
       execElement?.classList.add(styles.execButton)
+      if (execElement !== null) execElement.disabled = true
     }
   })
 

--- a/src/contents/style.module.css
+++ b/src/contents/style.module.css
@@ -1,15 +1,21 @@
 :root {
     --gmg-exec-button-color: #ff8c00;
     --gmg-select-button-color: #ff8c00;
+    --gmg-select-button-disabled-color: #7d8590;
     --gmg-menu-button-color: #ff8c00;
 }
 
-.execButton:not(:disabled) {
+.execButton {
     background-color: var(--gmg-exec-button-color) !important;
 }
 
-.selectButton:not(:disabled) {
+.selectButton,
+.selectButton > div {
     background-color: var(--gmg-select-button-color) !important;
+}
+
+.selectButton * {
+    color: var(--gmg-select-button-disabled-color) !important;
 }
 
 .menuButton {


### PR DESCRIPTION
To prevent accidental merging, the merge button is disabled when the merge strategy doesn't match the configured rules.

![スクリーンショット 2023-08-06 21 41 40](https://github.com/blajir/github-merge-guardian/assets/19278006/e2d56f2a-e284-4401-bb36-10281654d978)
