### PR TITLE
feat: disable when auto merge enabled

### DIFF
--- a/src/lib/selector.ts
+++ b/src/lib/selector.ts
@@ -64,6 +64,8 @@ export const selectParentStrategyExecElement = () => {
 export const selectStrategyExecButtonElement = (storategy: Strategy) => {
   return document.querySelector<HTMLButtonElement>(
     `.merge-message .merge-box-button.${execButtonClass(storategy)}`
+  ) ?? document.querySelector<HTMLButtonElement>(
+    `.merge-message .${execButtonClass(storategy)}`
   )
 }
 


### PR DESCRIPTION
When branch protection is enabled, the .merge-box-button is not present in the merge button dom. Therefore, the merge button is pressed regardless of the merge strategy.
![スクリーンショット 2023-08-07 20 08 58](https://github.com/blajir/github-merge-guardian/assets/19278006/29afb4be-ef48-4c36-ae67-c5e9d3a5c362)

Fixed selectStrategyExecButtonElement function to get dom.
![スクリーンショット 2023-08-07 20 13 53](https://github.com/blajir/github-merge-guardian/assets/19278006/1b6d1566-422d-404e-a80f-eee3b0b1df37)

